### PR TITLE
5 system modeller deployment with ssm adaptor

### DIFF
--- a/.env
+++ b/.env
@@ -37,4 +37,4 @@ KEYCLOAK_ADMIN_PASSWORD=password
 DOCUMENTATION_URL=https://spyderisk.org/documentation/modeller/latest/
 
 # Version of SPYDERISK System Modeller to use
-SPYDERISK_VERSION=dev-20230424T1738
+SPYDERISK_VERSION=dev-20231025T1200

--- a/.env
+++ b/.env
@@ -38,3 +38,7 @@ DOCUMENTATION_URL=https://spyderisk.org/documentation/modeller/latest/
 
 # Version of SPYDERISK System Modeller to use
 SPYDERISK_VERSION=dev-20231025T1200
+
+# Version of SPYDERISK System Modeller Adaptor to use
+SPYDERISK_ADAPTOR_VERSION=dev-20231026T1640
+

--- a/.env
+++ b/.env
@@ -37,7 +37,7 @@ KEYCLOAK_ADMIN_PASSWORD=password
 DOCUMENTATION_URL=https://spyderisk.org/documentation/modeller/latest/
 
 # Version of SPYDERISK System Modeller to use
-SPYDERISK_VERSION=dev-20231025T1200
+SPYDERISK_VERSION=dev-20231107T1030
 
 # Version of SPYDERISK System Modeller Adaptor to use
 SPYDERISK_ADAPTOR_VERSION=dev-20231026T1640

--- a/.env_adaptor
+++ b/.env_adaptor
@@ -9,7 +9,7 @@ SSM_ADAPTOR_MODE=all
 ROOT_PATH=/system-modeller/adaptor
 
 # SSM Service URL
-SSM_URL=http://ssm-proxy:80/system-modeller
+SSM_URL=http://proxy:80/system-modeller
 #SSM_URL=http://host.host.internal:8089/system-modeller
 
 # mongo db

--- a/.env_adaptor
+++ b/.env_adaptor
@@ -1,0 +1,68 @@
+# SSM-Adaptor Configuration Variables
+#
+PROJECT_NAME=SSM Adaptor Microservice tm
+
+# Adaptor mode: values [All, ProTego, FogProtect]
+SSM_ADAPTOR_MODE=all
+
+# APP ROOT_PATH e.g. Proxy URL in WebServer config
+ROOT_PATH=/system-modeller/adaptor
+
+# SSM Service URL
+SSM_URL=http://ssm-proxy:80/system-modeller
+#SSM_URL=http://host.host.internal:8089/system-modeller
+
+# mongo db
+#MONGO_HOST=mongo
+
+# data/log folders
+DATA_FOLDER=/data
+LOG_FOLDER=/logs
+
+# External services configuration parameters
+#UDE_SERVICE_URL=
+#OUTBOUND_REQUEST_TIMEOUT=30
+
+# KAFKA parameters
+KAFKA_ENABLED=False
+#KAFKA_SERVICE_URL=<kafka-url:30388>
+#KAFKA_TOPIC_NAME=ssm
+
+# POLLING DELAYS
+POLLING_DELAY_1=4
+POLLING_DELAY_2=2
+
+# LOG Info, default console
+#LOGFILE=ssm_adaptor.log
+LOGGING_LEVEL=DEBUG
+
+# Other parameters
+# Use MAX_RISKS to limit the returned risk (misbehaviour) data items (-1 represents unlimited)
+MAX_RISKS=10
+
+# Value to return in risks response to indicate acceptable risk value
+ACCEPTABLE_RISK_LEVEL=Medium
+
+# Normally we filter out low-level risks (misbehaviours) from results
+FILTER_LOW_LEVEL_RISKS=TRUE
+
+# Fogprotect parameters
+GET_ASSET_METADATA_FROM_VULN=TRUE
+FP_DISABLEMENT_CONTROL=DisabledDataFlow
+
+# Risk calc default mode (CURRENT/FUTURE)
+RISK_CALC_MODE=CURRENT
+
+# Cyberkit4SME parameters
+OPENVAS_REPORT_FILE_LOCATION=/code/tmp
+
+# Max number of threats to exploit for recommendations
+MAX_THREATS=10
+
+# Domain model version number: values [4, 5]
+DOMAIN_MODEL_VERSION=5
+
+# Version of SPYDERISK System Modeller Adaptor to use
+#SPYDERISK_ADAPTOR_VERSION=dev-2023xxxxx
+SPYDERISK_ADAPTOR_VERSION=latest
+

--- a/.env_adaptor
+++ b/.env_adaptor
@@ -62,7 +62,3 @@ MAX_THREATS=10
 # Domain model version number: values [4, 5]
 DOMAIN_MODEL_VERSION=5
 
-# Version of SPYDERISK System Modeller Adaptor to use
-#SPYDERISK_ADAPTOR_VERSION=dev-2023xxxxx
-SPYDERISK_ADAPTOR_VERSION=latest
-

--- a/.env_adaptor
+++ b/.env_adaptor
@@ -1,6 +1,6 @@
 # SSM-Adaptor Configuration Variables
 #
-PROJECT_NAME=SSM Adaptor Microservice tm
+PROJECT_NAME=SSM Adaptor Microservice
 
 # Adaptor mode: values [All, ProTego, FogProtect]
 SSM_ADAPTOR_MODE=all
@@ -10,7 +10,6 @@ ROOT_PATH=/system-modeller/adaptor
 
 # SSM Service URL
 SSM_URL=http://proxy:80/system-modeller
-#SSM_URL=http://host.host.internal:8089/system-modeller
 
 # mongo db
 #MONGO_HOST=mongo

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# SPYDERISK System Modeller Deployment Project
+# Spyderisk System Modeller Deployment Project
 
 ## Overview
 
 The purpose of this project is to provide a configured system that can deploy
-the dockerised SPYDERISK software on a server along with keycloak and mongo
+the dockerised Spyderisk software on a server along with keycloak and mongo
 containers.
 
 The deployment would be with `docker-compose` executed directly on the server
@@ -46,7 +46,7 @@ See below for details.
 
 ### Deployment on a Laptop
 
-The SPYDERISK software must be configured so that there is a single URL used to
+The Spyderisk software must be configured so that there is a single URL used to
 access Keycloak. The `docker-compose.yml` file sets the address to be
 `${SERVICE_PROTOCOL}://${SERVICE_DOMAIN}:${SERVICE_PORT}/auth/`.
 
@@ -110,7 +110,7 @@ compose file, e.g. `docker-compose -f docker-compose_external_kc.yml up -d`.
 Multiple deployments of the dockerised SSM can co-exist on the same server.
 Each deployment requires its own folder, and adjusted PORT settings.
 
-- copy the system-modeller-deployment to a folder with a different name e.g. `security1a`
+- copy the system-modeller-deployment to a folder with a different name e.g. `security1`
 - edit `.env` and use different names values for:
   - update `SERVICE_DOMAIN` to a different name than the first deployment SERVICE_DOMAIN
   - update `PROXY_EXTERNAL_PORT` to a different value than the first deployment PROXY_EXTERNAL_PORT

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ This project orchestrates:
   endpoints:
 
   * /system-modeller -> /system-modeller on the `ssm` container;
+  * /system-modeller/adaptor -> /system-modeller/adaptor on the `adaptor` container;
   * /auth -> /auth on the `keycloak` container;
   * /documentation -> the documentation website.
 
 * the system-modeller (`ssm` container);
 * Keycloak
 * MongoDB
+* SSM-Adaptor
 
 The orchestration is defined in a `docker-compose.yml` file.
 
@@ -35,6 +37,7 @@ relevant section [below](#Deployment using an external keycloak service).
 General method:
 
 1. Edit the `.env` file to set appropriate values.
+1. Edit the `.env_adaptor` file to set appropriate values.
 2. `docker-compose pull` to get the latest images (otherwise the locally cached
    ones are used, if they are there).
 3. `docker-compose up -d` to start the containers.
@@ -254,6 +257,7 @@ Stopping system-modeller-deployment_proxy_1    ... done
 Stopping system-modeller-deployment_ssm_1      ... done
 Stopping system-modeller-deployment_mongo_1    ... done
 Stopping system-modeller-deployment_keycloak_1 ... done
+Stopping ssm-adaptor                           ... done
 ```
 
 3. Remove the SSM container (using the name from the list in the previous

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ General method:
 1. Edit the `.env` file to set appropriate values.
 1. Edit the `.env_adaptor` file to set appropriate values.
 3. Download the most recent [knowledgebase](https://github.com/Spyderisk/domain-network/packages/1826148)
-   e.g. `domain-network-6a3-2-2.zip` and paste it into the `knowledgebases` folder.
+   e.g. `domain-network-6a3-2-2.zip` and copy it into the `knowledgebases` folder.
 2. Run `docker-compose pull` to get the latest images (otherwise the locally cached
    ones are used, if they are there).
 4. Run `docker-compose up -d` to start the containers.

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ General method:
 
 1. Edit the `.env` file to set appropriate values.
 1. Edit the `.env_adaptor` file to set appropriate values.
-2. `docker-compose pull` to get the latest images (otherwise the locally cached
+3. Download the most recent [knowledgebase](https://github.com/Spyderisk/domain-network/packages/1826148)
+   e.g. `domain-network-6a3-2-2.zip` and paste it into the `knowledgebases` folder.
+2. Run `docker-compose pull` to get the latest images (otherwise the locally cached
    ones are used, if they are there).
-3. `docker-compose up -d` to start the containers.
+4. Run `docker-compose up -d` to start the containers.
 
 See below for details.
 
@@ -208,10 +210,11 @@ docker-compose ps
 
        Name                     Command               State          Ports
 ----------------------------------------------------------------------------------
-example_keycloak_1   /opt/jboss/tools/docker-en ...   Up      8080/tcp, 8443/tcp
-example_mongo_1      docker-entrypoint.sh mongod      Up      27017/tcp
-example_proxy_1      /docker-entrypoint.sh /bin ...   Up      0.0.0.0:8083->80/tcp
-example_ssm_1        /var/lib/tomcat/bin/catali ...   Up
+example_adaptor_1    gunicorn -b 0.0.0.0:8000 - ...   Up                                                 
+example_keycloak_1   /tmp/import/entrypoint.sh        Up (healthy)   8080/tcp, 8443/tcp                  
+example_mongo_1      docker-entrypoint.sh mongod      Up             27017/tcp                           
+example_proxy_1      /tmp/import/entrypoint_tra ...   Up             0.0.0.0:8086->80/tcp,:::8086->80/tcp
+example_ssm_1        /var/lib/tomcat/bin/catali ...   Up                                                 
 ```
 
 The use, e.g.:

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Stopping system-modeller-deployment_proxy_1    ... done
 Stopping system-modeller-deployment_ssm_1      ... done
 Stopping system-modeller-deployment_mongo_1    ... done
 Stopping system-modeller-deployment_keycloak_1 ... done
-Stopping ssm-adaptor                           ... done
+Stopping system-modeller-deployment_adaptor    ... done
 ```
 
 3. Remove the SSM container (using the name from the list in the previous

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
   proxy:
     image: nginx:stable-alpine3.17
     # If there are multiple deployments of the SSM on the same host then they each need to expose a different PROXY_EXTERNAL_PORT
-    container_name: ssm-proxy
     ports:
       - ${PROXY_EXTERNAL_PORT}:80
     expose:
@@ -24,7 +23,7 @@ services:
     depends_on:
       - ssm
       - keycloak
-      - ssm-adaptor
+      - adaptor
     entrypoint: /tmp/import/entrypoint.sh
     volumes:
       - type: bind
@@ -35,7 +34,6 @@ services:
 
   ssm:
     image: spyderisk/system-modeller:${SPYDERISK_VERSION}
-    container_name: ssm
     restart: on-failure
     environment:
       # The "SPRING" env variables override the values in application.properties
@@ -93,7 +91,6 @@ services:
 
   mongo:
     image: mongo:5.0.16-focal
-    container_name: mongo
     restart: on-failure
     volumes:
       - type: volume
@@ -105,9 +102,8 @@ services:
     networks:
       - smd_net
 
-  ssm-adaptor:
+  adaptor:
     image: spyderisk/system-modeller-adaptor:${SPYDERISK_ADAPTOR_VERSION}
-    container_name: ssm-adaptor
     command: 'gunicorn -b 0.0.0.0:8000 -t 0 -w 4 -k uvicorn.workers.UvicornWorker app.main:app'
     env_file:
       - .env_adaptor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     depends_on:
       - ssm
       - keycloak
+      - ssm-adaptor
     entrypoint: /tmp/import/entrypoint.sh
     volumes:
       - type: bind
@@ -104,6 +105,18 @@ services:
     networks:
       - smd_net
 
+  ssm-adaptor:
+    image: spyderisk/system-modeller-adaptor:${SPYDERISK_ADAPTOR_VERSION}
+    container_name: ssm-adaptor
+    command: 'gunicorn -b 0.0.0.0:8000 -t 0 -w 4 -k uvicorn.workers.UvicornWorker app.main:app'
+    env_file:
+      - .env_adaptor
+    ports:
+      - '17643:8000'
+    networks:
+      - smd_net
+    depends_on:
+      - mongo
 
 networks:
   smd_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,8 +111,6 @@ services:
     command: 'gunicorn -b 0.0.0.0:8000 -t 0 -w 4 -k uvicorn.workers.UvicornWorker app.main:app'
     env_file:
       - .env_adaptor
-    ports:
-      - '17643:8000'
     networks:
       - smd_net
     depends_on:

--- a/docker-compose_external_kc.yml
+++ b/docker-compose_external_kc.yml
@@ -7,7 +7,6 @@ services:
   proxy:
     image: nginx:stable-alpine3.17
     # If there are multiple deployments of the SSM on the same host then they each need to expose a different PROXY_EXTERNAL_PORT
-    container_name: ssm-proxy
     ports:
       - ${PROXY_EXTERNAL_PORT}:80
     expose:
@@ -22,7 +21,7 @@ services:
     restart: on-failure
     depends_on:
       - ssm
-      - ssm-adaptor
+      - adaptor
     entrypoint: /tmp/import/entrypoint_no_kc.sh
     volumes:
       - type: bind
@@ -33,7 +32,6 @@ services:
 
   ssm:
     image: spyderisk/system-modeller:${SPYDERISK_VERSION}
-    container_name: ssm
     restart: on-failure
     environment:
       # The "SPRING" env variables override the values in application.properties
@@ -67,7 +65,6 @@ services:
 
   mongo:
     image: mongo:5.0.16-focal
-    container_name: mongo
     restart: on-failure
     volumes:
       - type: volume
@@ -79,14 +76,11 @@ services:
     networks:
       - smd_net
 
-  ssm-adaptor:
+  adaptor:
     image: spyderisk/system-modeller-adaptor:${SPYDERISK_ADAPTOR_VERSION}
-    container_name: ssm-adaptor
     command: 'gunicorn -b 0.0.0.0:8000 -t 0 -w 4 -k uvicorn.workers.UvicornWorker app.main:app'
     env_file:
       - .env_adaptor
-    ports:
-      - '17643:8000'
     networks:
       - smd_net
     depends_on:

--- a/docker-compose_external_kc.yml
+++ b/docker-compose_external_kc.yml
@@ -22,6 +22,7 @@ services:
     restart: on-failure
     depends_on:
       - ssm
+      - ssm-adaptor
     entrypoint: /tmp/import/entrypoint_no_kc.sh
     volumes:
       - type: bind
@@ -77,6 +78,19 @@ services:
         target: /data/configdb
     networks:
       - smd_net
+
+  ssm-adaptor:
+    image: spyderisk/system-modeller-adaptor:${SPYDERISK_ADAPTOR_VERSION}
+    container_name: ssm-adaptor
+    command: 'gunicorn -b 0.0.0.0:8000 -t 0 -w 4 -k uvicorn.workers.UvicornWorker app.main:app'
+    env_file:
+      - .env_adaptor
+    ports:
+      - '17643:8000'
+    networks:
+      - smd_net
+    depends_on:
+      - mongo
 
 networks:
   smd_net:

--- a/provisioning/nginx/nginx.conf.template
+++ b/provisioning/nginx/nginx.conf.template
@@ -45,7 +45,7 @@ http {
             rewrite ^(.*)$ http://$http_host$1/ redirect;
         }
         location /system-modeller/adaptor/ {
-            proxy_pass http://ssm-adaptor:8000/;
+            proxy_pass http://adaptor:8000/;
         }
 
         location / {

--- a/provisioning/nginx/nginx.conf.template
+++ b/provisioning/nginx/nginx.conf.template
@@ -41,6 +41,13 @@ http {
         # For each endpoint, we are explicit about how to treat URLs without a trailing slash. Not doing this causes some hidden problems.
         # $scheme and $http_host come from the request URL and are e.g. "https" and "some.domain:port". They are needed to preserve this part of the URL.
 
+        location /system-modeller/adaptor {
+            rewrite ^(.*)$ http://$http_host$1/ redirect;
+        }
+        location /system-modeller/adaptor/ {
+            proxy_pass http://ssm-adaptor:8000/;
+        }
+
         location / {
             return 301 $scheme://$http_host/system-modeller/;
         }

--- a/provisioning/nginx/nginx_no_kc.conf.template
+++ b/provisioning/nginx/nginx_no_kc.conf.template
@@ -45,7 +45,7 @@ http {
             rewrite ^(.*)$ http://$http_host$1/ redirect;
         }
         location /system-modeller/adaptor/ {
-            proxy_pass http://ssm-adaptor:8000/;
+            proxy_pass http://adaptor:8000/;
         }
 
         location / {

--- a/provisioning/nginx/nginx_no_kc.conf.template
+++ b/provisioning/nginx/nginx_no_kc.conf.template
@@ -41,6 +41,16 @@ http {
         # For each endpoint, we are explicit about how to treat URLs without a trailing slash. Not doing this causes some hidden problems.
         # $scheme and $http_host come from the request URL and are e.g. "https" and "some.domain:port". They are needed to preserve this part of the URL.
 
+        location /system-modeller/adaptor {
+            rewrite ^(.*)$ http://$http_host$1/ redirect;
+        }
+        location /system-modeller/adaptor/ {
+            proxy_pass http://ssm-adaptor:8000/;
+        }
+
+        location / {
+            return 301 $scheme://$http_host/system-modeller/;
+        }
         location = /system-modeller {
             rewrite ^(.*)$ $scheme://$http_host$1/ redirect;
         }


### PR DESCRIPTION
Next steps:
- merge with main, in that case Spyderisk deployment will always deploy ssm-adaptor. This will require ssm-adaptor updates each time Spyderisk API changes.
- rename files, e.g. `docker-compose-adaptor.yml`, etc. This solution will require renaming other files too, including *nginx.conf*, etc.
- keep the branch as it is, separate from **main** and update it regularly